### PR TITLE
EMP-945 fix clearing multiple bits in power control chip

### DIFF
--- a/arch/arm/mach-sunxi/pmic_bus.c
+++ b/arch/arm/mach-sunxi/pmic_bus.c
@@ -95,7 +95,7 @@ int pmic_bus_setbits(u8 reg, u8 bits)
 	if (ret)
 		return ret;
 
-	if (val & bits)
+	if ((val & bits) == bits)
 		return 0;
 
 	val |= bits;


### PR DESCRIPTION
The code for setting bits in the PMIC chip's register was optimized in an earlier commit. This optimized code introduced a bug where setting 1 bit worked but setting multiple bits might fail if one of the other bits was already set.

EMP-945